### PR TITLE
Show "login (name)" for reviewers in TreeView & implement reviewers sort

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -70,11 +70,11 @@ export class Action {
   }
 
   static async onRefresh (treeDataProvider: TreeDataProvider) {
-    Logger.logInfo('Start refreshing');
-    treeDataProvider.tree = await TreeCreator.createTree();
+    Logger.showInfo('Start TreeView refreshing. Please, wait');
+    treeDataProvider.tree = await TreeCreator.createTree(true);
     Logger.logInfo('Tree is created');
     treeDataProvider.refresh();
-    Logger.logInfo('Tree is refreshed');
+    Logger.showInfo('TreeView is refreshed successfully.');
   }
 
   static async onContinue () {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,15 @@
-import { commands, window } from 'vscode';
+import { commands, ExtensionContext, window } from 'vscode';
 import TreeDataProvider from './tree/dataProvider';
 import { Action } from './actions';
+import Storage from './storage';
 import GithubClient from './github/client';
 import Git from './git/client';
 
-export async function activate () {
+export async function activate (context: ExtensionContext) {
   const treeDataProvider = new TreeDataProvider();
   await Git.init();
   await GithubClient.init();
+  Storage.setStorage(context.globalState);
 
   window.createTreeView('GitCherry.main', { treeDataProvider, showCollapseAll: true });
   commands.registerCommand('GitCherry.pull_request', () => Action.onPullRequest(treeDataProvider));

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -46,6 +46,12 @@ export default class GithubClient {
       return getData(await GithubClient.octokit.issues.listLabelsForRepo(GithubClient.repoData)) as LabelsDataType;
     }
 
+    static async getContributorName (username: string): Promise<string | null> {
+      const info = await GithubClient.octokit.users.getByUsername({ username });
+
+      return info.data.name;
+    }
+
     static async getReviewers (): Promise<ReviewersDataType> {
       const getDataFromPage = async (page: number) => {
         return getData(await GithubClient.octokit.repos.listCollaborators(Object.assign({}, GithubClient.repoData, { per_page: 100, page }))) || [];

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,15 @@
+import { Memento } from 'vscode';
+
+export const REVIEWERS = 'reviewers';
+
+export default class Storage {
+  private static storage: Memento;
+
+  public static setStorage (_storage: Memento) {
+    Storage.storage = _storage;
+  }
+
+  public static getStorage (): Memento {
+    return Storage.storage;
+  }
+}

--- a/src/tree/getReviewersPayload.ts
+++ b/src/tree/getReviewersPayload.ts
@@ -1,0 +1,39 @@
+import Storage, { REVIEWERS } from '../storage';
+import GithubClient from '../github/client';
+
+async function createReviewerPayload () : Promise<string[]> {
+  const { login } = await GithubClient.getUser();
+  let reviewers = await GithubClient.getReviewers();
+  reviewers = reviewers.filter((reviewer: { login: string }) => reviewer.login !== login);
+
+  for (let i = 0; i < reviewers.length; ++i) {
+    const login = reviewers[i].login;
+    const name = await GithubClient.getContributorName(login);
+    if (name) {
+      reviewers[i].login = `${name} (${login})`;
+    }
+  }
+  return reviewers.sort(({ login: a }: {login: string}, { login: b }: {login: string}) => {
+    return a.localeCompare(b);
+  });
+}
+
+async function getReviewersPayload (ignoreCache?: boolean) : Promise<string[]> {
+  const storage = Storage.getStorage();
+  let result;
+
+  if (!ignoreCache) {
+    result = storage.get(REVIEWERS) as any[];
+  }
+
+  if (!result) {
+    result = await createReviewerPayload();
+    storage.update(REVIEWERS, result);
+  }
+
+  return result;
+}
+
+export {
+  getReviewersPayload
+};


### PR DESCRIPTION
Now:
- reviewers are sorted
- reviewers are shown as `login (full_name)`
- data caching is implemented
- information messages are shown on refresh start and finish